### PR TITLE
[OSDOCS-2343]: Added etcd as a control plane option

### DIFF
--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -12,9 +12,9 @@ Cluster administrators can choose which TLS security profile to use for each of 
 * the Ingress Controller
 * the control plane
 +
-This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, and OpenShift OAuth server.
+This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, OpenShift OAuth server, and etcd.
 +
-// NOTE: etcd and OpenShift controller manager are not included
+// NOTE: OpenShift controller manager are not included
 
 * the kubelet, when it acts as an HTTP server for the Kubernetes API server
 


### PR DESCRIPTION
 Added support for etcd as a control plane component in configuring TLS security profiles section, as of OpenShift 4.9.