### PR TITLE
OSDOCS#10150: Update product versions in the OPP user guide

### DIFF
--- a/architecture/opp-architecture.adoc
+++ b/architecture/opp-architecture.adoc
@@ -1,6 +1,6 @@
 [id="opp-architecture"]
 = {product-title} overview
-include::_attributes/common-attributes.adoc[]
+include::attributes/common-attributes.adoc[]
 :context: opp-architecture
 
 toc::[]
@@ -17,8 +17,8 @@ include::modules/opp-architecture-architecture.adoc[leveloffset=+1]
 include::modules/opp-architecture-installation.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/installing[Installing {rh-rhacm}]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing[Installing {rh-rhacm}]
 
 include::modules/opp-architecture-installing-policyset.adoc[leveloffset=+2]
 include::modules/opp-architecture-relnotes.adoc[leveloffset=+1]

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -8,8 +8,8 @@
 
 The release note information for each product is accessible from the following list:
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/release_notes/index[{ocp}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/release_notes/red-hat-advanced-cluster-management-for-kubernetes-release-notes[{rh-rhacm} for Kubernetes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.8/html/red_hat_quay_release_notes/index[{quay} Release Notes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.74/html/release_notes/index[{acs} for Kubernetes 3.7.4]
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/4.12_release_notes/index[{rh-storage-data-foundation}]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/release_notes/index[{ocp}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/release_notes/release-notes[{rh-rhacm} for Kubernetes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.11/html/red_hat_quay_release_notes/index[{quay} Release Notes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.4/html/release_notes/index[{acs} for Kubernetes 4.4]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/4.15_release_notes/index[{rh-storage-data-foundation}]


### PR DESCRIPTION
Version(s): 
This PR is based on the ‘opp-docs’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Issue:
[OSDOCS-10150](https://issues.redhat.com/browse/OSDOCS-10150)

Link to docs preview: tbd (Updated: 4/3/2024)

QE review:
- [ ] QE has approved this change.

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.

